### PR TITLE
bug: Use availabilityZones provided in AWSMachinePool when creating ASG

### DIFF
--- a/exp/api/v1alpha4/types.go
+++ b/exp/api/v1alpha4/types.go
@@ -182,6 +182,7 @@ type AutoScalingGroup struct {
 	Subnets           []string        `json:"subnets,omitempty"`
 	DefaultCoolDown   metav1.Duration `json:"defaultCoolDown,omitempty"`
 	CapacityRebalance bool            `json:"capacityRebalance,omitempty"`
+	AvailabilityZones []string        `json:"availabilityZones,omitempty"`
 
 	MixedInstancesPolicy *MixedInstancesPolicy `json:"mixedInstancesPolicy,omitempty"`
 	Status               ASGStatus

--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -42,6 +42,7 @@ func (s *Service) SDKToAutoScalingGroup(v *autoscaling.Group) (*expinfrav1.AutoS
 		MaxSize:           int32(aws.Int64Value(v.MaxSize)),
 		MinSize:           int32(aws.Int64Value(v.MinSize)),
 		CapacityRebalance: aws.BoolValue(v.CapacityRebalance),
+		AvailabilityZones: aws.StringValueSlice(v.AvailabilityZones),
 		//TODO: determine what additional values go here and what else should be in the struct
 	}
 
@@ -156,6 +157,7 @@ func (s *Service) CreateASG(scope *scope.MachinePoolScope) (*expinfrav1.AutoScal
 		DefaultCoolDown:      scope.AWSMachinePool.Spec.DefaultCoolDown,
 		CapacityRebalance:    scope.AWSMachinePool.Spec.CapacityRebalance,
 		MixedInstancesPolicy: scope.AWSMachinePool.Spec.MixedInstancesPolicy,
+		AvailabilityZones:    scope.AWSMachinePool.Spec.AvailabilityZones,
 	}
 
 	if scope.MachinePool.Spec.Replicas != nil {
@@ -202,6 +204,10 @@ func (s *Service) runPool(i *expinfrav1.AutoScalingGroup, launchTemplateID strin
 		VPCZoneIdentifier:    aws.String(strings.Join(i.Subnets, ", ")),
 		DefaultCooldown:      aws.Int64(int64(i.DefaultCoolDown.Duration.Seconds())),
 		CapacityRebalance:    aws.Bool(i.CapacityRebalance),
+	}
+
+	if i.AvailabilityZones != nil {
+		input.AvailabilityZones = aws.StringSlice(i.AvailabilityZones)
 	}
 
 	if i.DesiredCapacity != nil {

--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -143,6 +143,7 @@ func TestService_SDKToAutoScalingGroup(t *testing.T) {
 				MaxSize:              aws.Int64(1234),
 				MinSize:              aws.Int64(1234),
 				CapacityRebalance:    aws.Bool(true),
+				AvailabilityZones:    aws.StringSlice([]string{"test-az"}),
 				MixedInstancesPolicy: &autoscaling.MixedInstancesPolicy{
 					InstancesDistribution: &autoscaling.InstancesDistribution{
 						OnDemandAllocationStrategy:          aws.String("prioritized"),
@@ -167,6 +168,7 @@ func TestService_SDKToAutoScalingGroup(t *testing.T) {
 				MaxSize:           int32(1234),
 				MinSize:           int32(1234),
 				CapacityRebalance: true,
+				AvailabilityZones: []string{"test-az"},
 				MixedInstancesPolicy: &expinfrav1.MixedInstancesPolicy{
 					InstancesDistribution: &expinfrav1.InstancesDistribution{
 						OnDemandAllocationStrategy:          expinfrav1.OnDemandAllocationStrategyPrioritized,
@@ -192,6 +194,7 @@ func TestService_SDKToAutoScalingGroup(t *testing.T) {
 				MaxSize:              aws.Int64(1234),
 				MinSize:              aws.Int64(1234),
 				CapacityRebalance:    aws.Bool(true),
+				AvailabilityZones:    aws.StringSlice([]string{"test-az"}),
 				MixedInstancesPolicy: nil,
 			},
 			want: &expinfrav1.AutoScalingGroup{
@@ -201,6 +204,7 @@ func TestService_SDKToAutoScalingGroup(t *testing.T) {
 				MaxSize:              int32(1234),
 				MinSize:              int32(1234),
 				CapacityRebalance:    true,
+				AvailabilityZones:    []string{"test-az"},
 				MixedInstancesPolicy: nil,
 			},
 			wantErr: false,


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

Currently the `AWSMachinePoolSpec availabilityZones` field is not used during ASG creation. With this, the choice of availabilityZones specified in the CR will be reflected in the AWS auto scaling group.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2320

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Use the AWSMachinePoolSpec availabilityZones field during ASG creation
```
